### PR TITLE
feat: persist theme selection using rehooks/local-storage

### DIFF
--- a/src/main/webui/package-lock.json
+++ b/src/main/webui/package-lock.json
@@ -10,6 +10,7 @@
          "dependencies": {
             "@popperjs/core": "^2.11.8",
             "@preact/compat": "^17.1.2",
+            "@rehooks/local-storage": "^2.4.5",
             "bootstrap": "^5.3.3",
             "preact": "^10.22.0",
             "preact-i18n": "^2.4.0-preactx"
@@ -978,6 +979,18 @@
             "vite": ">=2.0.0"
          }
       },
+      "node_modules/@rehooks/local-storage": {
+         "version": "2.4.5",
+         "resolved": "https://registry.npmjs.org/@rehooks/local-storage/-/local-storage-2.4.5.tgz",
+         "integrity": "sha512-3Q4KtiUBaKoIDRK72BWfAy50ul6hbw29f/M7tyCzlMe2FbSsiQNok0WGeBLaYj4T2PJ7JMSJlSbUGY8RNsImmw==",
+         "license": "MIT",
+         "engines": {
+            "node": ">=18.0.0"
+         },
+         "peerDependencies": {
+            "react": ">=16.8.0"
+         }
+      },
       "node_modules/@rollup/pluginutils": {
          "version": "4.2.1",
          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
@@ -1806,7 +1819,6 @@
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-         "dev": true,
          "license": "MIT"
       },
       "node_modules/jsesc": {
@@ -1846,7 +1858,6 @@
          "version": "1.4.0",
          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-         "dev": true,
          "license": "MIT",
          "peer": true,
          "dependencies": {
@@ -2038,7 +2049,6 @@
          "version": "18.3.1",
          "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
          "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-         "dev": true,
          "license": "MIT",
          "peer": true,
          "dependencies": {

--- a/src/main/webui/package.json
+++ b/src/main/webui/package.json
@@ -11,6 +11,7 @@
    "dependencies": {
       "@popperjs/core": "^2.11.8",
       "@preact/compat": "^17.1.2",
+      "@rehooks/local-storage": "^2.4.5",
       "bootstrap": "^5.3.3",
       "preact": "^10.22.0",
       "preact-i18n": "^2.4.0-preactx"

--- a/src/main/webui/src/app.jsx
+++ b/src/main/webui/src/app.jsx
@@ -11,6 +11,9 @@ import * as bootstrap from 'bootstrap'
 import { ApplicationGroupList } from './ApplicationGroupList'
 import { BookmarkGroupList } from './BookmarkGroupList'
 
+import { useLocalStorage } from '@rehooks/local-storage';
+import { writeStorage } from '@rehooks/local-storage';
+
 export function ForkMe() {
   // if the config object is not empty and the web.showGitHubLink is true, show the fork me link
   //  if (config && config.web && config.web.showGitHubLink) {
@@ -25,6 +28,113 @@ export function ForkMe() {
   );
   // }
   // return null;
+}
+
+export function ThemeSwitcher(handleLightThemeClick, handleDarkThemeClick, handleAutoThemeClick) {
+
+  const [themeIcon, setThemeIcon] = useState("#circle-half");
+
+  const [theme] = useLocalStorage('theme', 'light');
+  useEffect(() => {
+    if (theme === 'light') {
+      handleLightThemeClick();
+    } else if (theme === 'dark') {
+      handleDarkThemeClick();
+    } else if (theme === 'auto') {
+      handleAutoThemeClick();
+    }
+  }, [])
+
+  function handleLightThemeClick(setIcon = true) {
+    console.log("light theme");
+
+    if (setIcon) {
+      setThemeIcon("#sun-fill");
+      writeStorage('theme', 'light');
+    }
+    document.body.style.setProperty('--bs-body-bg', '#F8F6F1');
+    document.body.style.setProperty('--bs-body-color', '#696969');
+    document.body.style.setProperty('--color-text-pri', '#4C432E');
+    document.body.style.setProperty('--color-text-acc', '#AA9A73');
+  }
+  function handleDarkThemeClick(setIcon = true) {
+    console.log("dark theme");
+
+    if (setIcon) {
+      setThemeIcon("#moon-stars-fill");
+      writeStorage('theme', 'dark');
+    }
+    document.body.style.setProperty('--bs-body-bg', '#232530');
+    document.body.style.setProperty('--bs-body-color', '#696969');
+    document.body.style.setProperty('--color-text-pri', '#FAB795');
+    document.body.style.setProperty('--color-text-acc', '#E95678');
+  }
+  function handleAutoThemeClick() {
+    console.log("auto theme");
+
+    setThemeIcon("#circle-half");
+
+    writeStorage('theme', 'auto');
+    // if its after dark, set dark theme
+    // else set light theme
+    const now = new Date();
+    const hour = now.getHours();
+    if (hour > 18 || hour < 6) {
+      handleDarkThemeClick(false);
+    } else {
+      handleLightThemeClick(false);
+    }
+  }
+
+  return (
+    <div class="dropdown position-fixed bottom-0 end-0 mb-3 me-3 bd-mode-toggle">
+      <button class="btn btn-bd-primary py-2 dropdown-toggle d-flex align-items-center" id="bd-theme" type="button"
+        aria-expanded="false" data-bs-toggle="dropdown" aria-label="Toggle theme (auto)">
+        <svg class="bi my-1 theme-icon-active" width="1em" height="1em">
+          <use href={themeIcon}></use>
+        </svg>
+        <span class="visually-hidden" id="bd-theme-text">Toggle theme</span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end shadow" aria-labelledby="bd-theme-text">
+        <li>
+          <button type="button" class="dropdown-item d-flex align-items-center {lightActive}" data-bs-theme-value="light"
+            aria-pressed="false" onClick={handleLightThemeClick}>
+            <svg class="bi me-2 opacity-50" width="1em" height="1em">
+              <use href="#sun-fill"></use>
+            </svg>
+            <Text id="home.theme.light">Light</Text>
+            <svg class="bi ms-auto d-none" width="1em" height="1em">
+              <use href="#check2"></use>
+            </svg>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="dropdown-item d-flex align-items-center {darkActive}" data-bs-theme-value="dark"
+            aria-pressed="false" onClick={handleDarkThemeClick}>
+            <svg class="bi me-2 opacity-50" width="1em" height="1em">
+              <use href="#moon-stars-fill"></use>
+            </svg>
+            <Text id="home.theme.dark">Dark</Text>
+            <svg class="bi ms-auto d-none" width="1em" height="1em">
+              <use href="#check2"></use>
+            </svg>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="dropdown-item d-flex align-items-center {autoActive}" data-bs-theme-value="auto"
+            aria-pressed="true" onClick={handleAutoThemeClick}>
+            <svg class="bi me-2 opacity-50" width="1em" height="1em">
+              <use href="#circle-half"></use>
+            </svg>
+            <Text id="home.theme.auto">Auto</Text>
+            <svg class="bi ms-auto d-none" width="1em" height="1em">
+              <use href="#check2"></use>
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </div>
+  );
 }
 
 export function App() {
@@ -89,32 +199,6 @@ export function App() {
     setShowBookmarks(false);
     setShowApplications(true);
   }
-  function handleLightThemeClick() {
-    console.log("light theme");
-    document.body.style.setProperty('--bs-body-bg', '#F8F6F1');
-    document.body.style.setProperty('--bs-body-color', '#696969');
-    document.body.style.setProperty('--color-text-pri', '#4C432E');
-    document.body.style.setProperty('--color-text-acc', '#AA9A73');
-  }
-  function handleDarkThemeClick() {
-    console.log("dark theme");
-    document.body.style.setProperty('--bs-body-bg', '#232530');
-    document.body.style.setProperty('--bs-body-color', '#696969');
-    document.body.style.setProperty('--color-text-pri', '#FAB795');
-    document.body.style.setProperty('--color-text-acc', '#E95678');
-  }
-  function handleAutoThemeClick() {
-    console.log("auto theme");
-    // if its after dark, set dark theme
-    // else set light theme
-    const now = new Date();
-    const hour = now.getHours();
-    if (hour > 18 || hour < 6) {
-      handleDarkThemeClick();
-    } else {
-      handleLightThemeClick();
-    }
-  }
 
   return (
     <IntlProvider definition={definition}>
@@ -139,53 +223,8 @@ export function App() {
         </symbol>
       </svg>
 
-      <div class="dropdown position-fixed bottom-0 end-0 mb-3 me-3 bd-mode-toggle">
-        <button class="btn btn-bd-primary py-2 dropdown-toggle d-flex align-items-center" id="bd-theme" type="button"
-          aria-expanded="false" data-bs-toggle="dropdown" aria-label="Toggle theme (auto)">
-          <svg class="bi my-1 theme-icon-active" width="1em" height="1em">
-            <use href="#circle-half"></use>
-          </svg>
-          <span class="visually-hidden" id="bd-theme-text">Toggle theme</span>
-        </button>
-        <ul class="dropdown-menu dropdown-menu-end shadow" aria-labelledby="bd-theme-text">
-          <li>
-            <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="light"
-              aria-pressed="false" onClick={handleLightThemeClick}>
-              <svg class="bi me-2 opacity-50" width="1em" height="1em">
-                <use href="#sun-fill"></use>
-              </svg>
-              <Text id="home.theme.light">Light</Text>
-              <svg class="bi ms-auto d-none" width="1em" height="1em">
-                <use href="#check2"></use>
-              </svg>
-            </button>
-          </li>
-          <li>
-            <button type="button" class="dropdown-item d-flex align-items-center" data-bs-theme-value="dark"
-              aria-pressed="false" onClick={handleDarkThemeClick}>
-              <svg class="bi me-2 opacity-50" width="1em" height="1em">
-                <use href="#moon-stars-fill"></use>
-              </svg>
-              <Text id="home.theme.dark">Dark</Text>
-              <svg class="bi ms-auto d-none" width="1em" height="1em">
-                <use href="#check2"></use>
-              </svg>
-            </button>
-          </li>
-          <li>
-            <button type="button" class="dropdown-item d-flex align-items-center active" data-bs-theme-value="auto"
-              aria-pressed="true" onClick={handleAutoThemeClick}>
-              <svg class="bi me-2 opacity-50" width="1em" height="1em">
-                <use href="#circle-half"></use>
-              </svg>
-              <Text id="home.theme.auto">Auto</Text>
-              <svg class="bi ms-auto d-none" width="1em" height="1em">
-                <use href="#check2"></use>
-              </svg>
-            </button>
-          </li>
-        </ul>
-      </div>
+      <ThemeSwitcher />
+
       <div class="cover-container d-flex w-100 h-100 p-3 mx-auto flex-column">
         <header class="mb-auto">
           <div>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
theme is reset to default each time you visit the page

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- the selected theme is persisted in local storage in the browser and recalled when you visit the page

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
