### PR TITLE
feat: Add tag support

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -47,8 +47,8 @@ jobs:
             echo "workflow run conclusion: ${{ github.event.workflow_run.conclusion }}"
 
             echo "run=${{
-              (github.repository == 'ullbergm/startpunkt' && (github.ref == 'refs/heads/dev') || startsWith(github.ref, 'refs/tags/v')) &&
-              (github.event_name == 'push' || (github.event_name == 'workflow_run' && (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch') && github.event.workflow_run.conclusion == 'success'))
+              (github.repository == 'ullbergm/startpunkt' && ((github.ref == 'refs/heads/dev') || startsWith(github.ref, 'refs/tags/v'))) &&
+              (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch') && github.event.workflow_run.conclusion == 'success'))
             }}" >>$GITHUB_OUTPUT
 
   build-jvm-images:

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ startpunkt:
 To add applications, that are either outside of the cluster or are using an ingress method that is not supported (yet), you can use the CRDs:
 
 ```yaml
-apiVersion: startpunkt.ullberg.us/v1alpha2
+apiVersion: startpunkt.ullberg.us/v1alpha3
 kind: Application
 metadata:
   name: nas
@@ -216,7 +216,7 @@ spec:
 For Startpunkt Application CRDs, you can use the `rootPath` property directly in the spec to append a path to the URL:
 
 ```yaml
-apiVersion: startpunkt.ullberg.us/v1alpha2
+apiVersion: startpunkt.ullberg.us/v1alpha3
 kind: Application
 metadata:
   name: web-app

--- a/deploy/kubernetes/charts/startpunkt/templates/crds.yaml
+++ b/deploy/kubernetes/charts/startpunkt/templates/crds.yaml
@@ -11,7 +11,58 @@ spec:
     singular: "application"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              enabled:
+                description: "Enable the bookmark"
+                type: "boolean"
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Application icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              iconColor:
+                description: "Application icon color, e.g. 'red'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Application name"
+                type: "string"
+              rootPath:
+                description: "Root path to append to the URL"
+                type: "string"
+              tags:
+                description: "Comma-separated tags for filtering applications"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Application URL"
+                type: "string"
+            required:
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
     schema:
       openAPIV3Schema:
         properties:
@@ -55,7 +106,7 @@ spec:
             type: "object"
         type: "object"
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true
@@ -116,7 +167,7 @@ spec:
     singular: "bookmark"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
     schema:
       openAPIV3Schema:
         properties:
@@ -153,6 +204,46 @@ spec:
         type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Bookmark icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Bookmark name"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Bookmark URL"
+                type: "string"
+            required:
+            - "group"
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true

--- a/deploy/kubernetes/startpunkt-jvm.yaml
+++ b/deploy/kubernetes/startpunkt-jvm.yaml
@@ -100,7 +100,58 @@ spec:
     singular: "application"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              enabled:
+                description: "Enable the bookmark"
+                type: "boolean"
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Application icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              iconColor:
+                description: "Application icon color, e.g. 'red'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Application name"
+                type: "string"
+              rootPath:
+                description: "Root path to append to the URL"
+                type: "string"
+              tags:
+                description: "Comma-separated tags for filtering applications"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Application URL"
+                type: "string"
+            required:
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
     schema:
       openAPIV3Schema:
         properties:
@@ -144,7 +195,7 @@ spec:
             type: "object"
         type: "object"
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true
@@ -205,7 +256,7 @@ spec:
     singular: "bookmark"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
     schema:
       openAPIV3Schema:
         properties:
@@ -242,6 +293,46 @@ spec:
         type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Bookmark icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Bookmark name"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Bookmark URL"
+                type: "string"
+            required:
+            - "group"
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true

--- a/deploy/kubernetes/startpunkt-native.yaml
+++ b/deploy/kubernetes/startpunkt-native.yaml
@@ -100,7 +100,58 @@ spec:
     singular: "application"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              enabled:
+                description: "Enable the bookmark"
+                type: "boolean"
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Application icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              iconColor:
+                description: "Application icon color, e.g. 'red'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Application name"
+                type: "string"
+              rootPath:
+                description: "Root path to append to the URL"
+                type: "string"
+              tags:
+                description: "Comma-separated tags for filtering applications"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Application URL"
+                type: "string"
+            required:
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
     schema:
       openAPIV3Schema:
         properties:
@@ -144,7 +195,7 @@ spec:
             type: "object"
         type: "object"
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true
@@ -205,7 +256,7 @@ spec:
     singular: "bookmark"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
     schema:
       openAPIV3Schema:
         properties:
@@ -242,6 +293,46 @@ spec:
         type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Bookmark icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Bookmark name"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Bookmark URL"
+                type: "string"
+            required:
+            - "group"
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true

--- a/deploy/openshift/startpunkt-jvm.yaml
+++ b/deploy/openshift/startpunkt-jvm.yaml
@@ -102,7 +102,58 @@ spec:
     singular: "application"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              enabled:
+                description: "Enable the bookmark"
+                type: "boolean"
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Application icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              iconColor:
+                description: "Application icon color, e.g. 'red'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Application name"
+                type: "string"
+              rootPath:
+                description: "Root path to append to the URL"
+                type: "string"
+              tags:
+                description: "Comma-separated tags for filtering applications"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Application URL"
+                type: "string"
+            required:
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
     schema:
       openAPIV3Schema:
         properties:
@@ -146,7 +197,7 @@ spec:
             type: "object"
         type: "object"
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true
@@ -207,7 +258,7 @@ spec:
     singular: "bookmark"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
     schema:
       openAPIV3Schema:
         properties:
@@ -244,6 +295,46 @@ spec:
         type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Bookmark icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Bookmark name"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Bookmark URL"
+                type: "string"
+            required:
+            - "group"
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true
@@ -286,6 +377,7 @@ spec:
     storage: false
     subresources:
       status: {}
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/openshift/startpunkt-native.yaml
+++ b/deploy/openshift/startpunkt-native.yaml
@@ -102,7 +102,58 @@ spec:
     singular: "application"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              enabled:
+                description: "Enable the bookmark"
+                type: "boolean"
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Application icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              iconColor:
+                description: "Application icon color, e.g. 'red'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Application name"
+                type: "string"
+              rootPath:
+                description: "Root path to append to the URL"
+                type: "string"
+              tags:
+                description: "Comma-separated tags for filtering applications"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Application URL"
+                type: "string"
+            required:
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
     schema:
       openAPIV3Schema:
         properties:
@@ -146,7 +197,7 @@ spec:
             type: "object"
         type: "object"
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true
@@ -207,7 +258,7 @@ spec:
     singular: "bookmark"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha2"
+  - name: "v1alpha3"
     schema:
       openAPIV3Schema:
         properties:
@@ -244,6 +295,46 @@ spec:
         type: "object"
     served: true
     storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    name: "v1alpha2"
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              group:
+                description: "Group the bookmark belongs to"
+                type: "string"
+              icon:
+                description: "Bookmark icon, e.g. 'mdi:home', 'https://example.com/icon.png'"
+                type: "string"
+              info:
+                description: "Description of the bookmark"
+                type: "string"
+              location:
+                description: "Sorting order of the bookmark"
+                type: "integer"
+              name:
+                description: "Bookmark name"
+                type: "string"
+              targetBlank:
+                description: "Open the URL in a new tab"
+                type: "boolean"
+              url:
+                description: "Bookmark URL"
+                type: "string"
+            required:
+            - "group"
+            - "name"
+            - "url"
+            type: "object"
+          status:
+            type: "object"
+        type: "object"
+    served: true
+    storage: false
     subresources:
       status: {}
   - deprecated: true

--- a/docs/object-tag-filtering.md
+++ b/docs/object-tag-filtering.md
@@ -1,0 +1,99 @@
+# Object Tag Filtering
+
+This feature allows filtering applications based on tags. You can filter applications by passing tags as URL parameters, showing only applications that match the specified tags or applications with no tags.
+
+## URL-Based Filtering
+
+You can filter applications by adding tags directly to the URL path:
+
+```url
+https://your-startpunkt-instance.com/admin
+https://your-startpunkt-instance.com/admin,dev
+https://your-startpunkt-instance.com/users
+```
+
+If no tags are specified in the URL, only applications without tags will be shown.
+
+## Kubernetes Resource Annotation
+
+Add the `startpunkt.ullberg.us/tags` annotation to your Kubernetes resources to specify which tag(s) the application should be associated with:
+
+### Example: Admin-tagged application
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: admin-dashboard
+  annotations:
+    startpunkt.ullberg.us/tags: "admin"
+    startpunkt.ullberg.us/enable: "true"
+spec:
+  # ... ingress spec
+```
+
+### Example: Multi-tagged application
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: dev-tool
+  annotations:
+    startpunkt.ullberg.us/tags: "admin,dev"
+    startpunkt.ullberg.us/enable: "true"
+spec:
+  # ... route spec
+```
+
+### Example: Untagged application (no tag filter)
+
+```yaml
+apiVersion: apps/v1
+kind: Application
+metadata:
+  name: common-app
+  annotations:
+    startpunkt.ullberg.us/enable: "true"
+    # No tags annotation - will be shown when no tags are filtered or with any tag filter
+spec:
+  # ... application spec
+```
+
+## Behavior
+
+- **No tags in URL**: Shows only applications without tags
+- **Tags specified in URL (e.g., `/admin`)**: Shows applications that either:
+  - Have matching tag(s) in the `startpunkt.ullberg.us/tags` annotation
+  - Have no tags annotation (untagged applications are always included when tags are specified)
+- **Multiple tags in URL (e.g., `/admin,dev`)**: Shows applications that have any of the specified tags, plus all untagged applications
+
+## Filtering Logic
+
+**When no tags are specified in the URL:**
+
+- Only applications without the `startpunkt.ullberg.us/tags` annotation (or with empty tags) are displayed
+
+**When tags are specified in the URL:**
+
+- An application will be displayed if:
+  1. The application has one or more matching tags, OR
+  2. The application has no tags annotation (untagged applications are always included when filtering by tags)
+
+This approach ensures that untagged applications are always accessible, either by browsing with no tags specified or when filtering by any specific tags.
+
+## Use Cases
+
+1. **Admin View**: `/admin`
+   - Shows applications tagged with "admin" and all untagged applications
+   
+2. **Developer View**: `/dev`
+   - Shows applications tagged with "dev" and all untagged applications
+   
+3. **Multi-tag View**: `/admin,dev`
+   - Shows applications tagged with "admin" OR "dev" and all untagged applications
+
+4. **Default View**: `/` (root path)
+   - Shows only untagged applications
+
+This approach allows flexible filtering of applications based on URL parameters while maintaining a single deployment and ensuring untagged applications remain accessible.

--- a/pom.xml
+++ b/pom.xml
@@ -575,7 +575,7 @@
                 <requireJavaVersion>
                   <version>[21,22)</version>
                 </requireJavaVersion>
-                <dependencyConvergence />
+                <dependencyConvergence></dependencyConvergence>
               </rules>
               <fail>true</fail>
             </configuration>
@@ -588,8 +588,8 @@
         <version>2.46.1</version>
         <configuration>
           <java>
-            <googleJavaFormat />
-            <removeUnusedImports />
+            <googleJavaFormat></googleJavaFormat>
+            <removeUnusedImports></removeUnusedImports>
           </java>
         </configuration>
         <executions>

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/Application.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/Application.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -11,10 +11,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Represents the CustomResource for an Application. Maps to the Kubernetes resource
- * "applications.startpunkt.ullberg.us" version "v1alpha2". Contains the spec and status for the
+ * "applications.startpunkt.ullberg.us" version "v1alpha3". Contains the spec and status for the
  * Application.
  */
-@Version(value = "v1alpha2", storage = false, served = true, deprecated = true)
+@Version(value = "v1alpha3", storage = true, served = true, deprecated = false)
 @Group("startpunkt.ullberg.us")
 @Plural("applications")
 public class Application extends CustomResource<ApplicationSpec, ApplicationStatus>
@@ -85,6 +85,40 @@ public class Application extends CustomResource<ApplicationSpec, ApplicationStat
     this.spec =
         new ApplicationSpec(
             name, group, icon, iconColor, url, info, targetBlank, location, enabled, rootPath);
+  }
+
+  /**
+   * Constructs an Application with the specified specification fields including tags.
+   *
+   * @param name the application name
+   * @param group the group the application belongs to
+   * @param icon the application icon
+   * @param iconColor the icon color
+   * @param url the application URL
+   * @param info additional information
+   * @param targetBlank whether to open URL in new tab
+   * @param location sorting order location
+   * @param enabled whether the application is enabled
+   * @param rootPath root path to append to the URL
+   * @param tags comma-separated tags for filtering
+   */
+  public Application(
+      String name,
+      String group,
+      String icon,
+      String iconColor,
+      String url,
+      String info,
+      Boolean targetBlank,
+      int location,
+      Boolean enabled,
+      String rootPath,
+      String tags) {
+    super();
+    // Initialize the spec of the custom resource with the provided values
+    this.spec =
+        new ApplicationSpec(
+            name, group, icon, iconColor, url, info, targetBlank, location, enabled, rootPath, tags);
   }
 
   // Override the hashCode method to generate a hash code based on the spec and status

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/ApplicationList.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/ApplicationList.java
@@ -1,0 +1,20 @@
+package us.ullberg.startpunkt.crd.v1alpha3;
+
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+
+/**
+ * Represents a list of {@link Application} custom resources. Extends DefaultKubernetesResourceList
+ * to provide type safety for collections of Application objects.
+ */
+public class ApplicationList extends DefaultKubernetesResourceList<Application> {
+  // No additional fields or methods are defined,
+  // this class simply serves as a type-safe list for Application custom resources
+
+  /**
+   * Creates an empty ApplicationList. Required to suppress warnings about the implicit default
+   * constructor.
+   */
+  public ApplicationList() {
+    super();
+  }
+}

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/ApplicationSpec.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/ApplicationSpec.java
@@ -1,0 +1,527 @@
+package us.ullberg.startpunkt.crd.v1alpha3;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.fabric8.generator.annotation.Required;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Represents a single application bookmark specification in the Startpunkt UI.
+ *
+ * <p>This object defines all metadata related to a user-facing bookmark or link, such as its name,
+ * group, URL, icon, sorting order, visibility, and display behavior. It is typically used as the
+ * spec section in a Kubernetes custom resource representing application shortcuts.
+ *
+ * <p>The {@code name} and {@code url} fields are required. Other fields are optional and enhance
+ * the UI experience.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@RegisterForReflection(registerFullHierarchy = true)
+public class ApplicationSpec implements Comparable<ApplicationSpec> {
+
+  /** Application name (required). */
+  @JsonProperty("name")
+  @JsonPropertyDescription("Application name")
+  @Required
+  public String name;
+
+  /** Group the bookmark belongs to. */
+  @JsonProperty("group")
+  @JsonPropertyDescription("Group the bookmark belongs to")
+  private String group;
+
+  /** Application icon, either as a name (e.g. mdi:home) or URL. */
+  @JsonProperty("icon")
+  @JsonPropertyDescription("Application icon, e.g. 'mdi:home', 'https://example.com/icon.png'")
+  private String icon;
+
+  /** Color for the application icon. */
+  @JsonProperty("iconColor")
+  @JsonPropertyDescription("Application icon color, e.g. 'red'")
+  private String iconColor;
+
+  /** Application URL (required). */
+  @JsonProperty("url")
+  @JsonPropertyDescription("Application URL")
+  @Required
+  private String url;
+
+  /** Description or additional info about the bookmark. */
+  @JsonProperty("info")
+  @JsonPropertyDescription("Description of the bookmark")
+  private String info;
+
+  /** Whether the link should open in a new browser tab. */
+  @JsonProperty("targetBlank")
+  @JsonPropertyDescription("Open the URL in a new tab")
+  private Boolean targetBlank;
+
+  /** Sorting order for the bookmark in the UI. */
+  @JsonProperty("location")
+  @JsonPropertyDescription("Sorting order of the bookmark")
+  private int location;
+
+  /** Whether the bookmark is enabled and should be shown. */
+  @JsonProperty("enabled")
+  @JsonPropertyDescription("Enable the bookmark")
+  private Boolean enabled;
+
+  /** Root path to append to the URL. */
+  @JsonProperty("rootPath")
+  @JsonPropertyDescription("Root path to append to the URL")
+  private String rootPath;
+
+  /** Comma-separated tags for filtering applications. */
+  @JsonProperty("tags")
+  @JsonPropertyDescription("Comma-separated tags for filtering applications")
+  private String tags;
+
+  /** Default constructor. */
+  public ApplicationSpec() {}
+
+  /**
+   * Parameterized constructor to initialize all fields.
+   *
+   * @param name the application name (required)
+   * @param group the group the bookmark belongs to
+   * @param icon the application icon
+   * @param iconColor the icon color
+   * @param url the application URL (required)
+   * @param info description of the bookmark
+   * @param targetBlank whether to open the URL in a new tab
+   * @param location sorting order of the bookmark
+   * @param enabled whether the bookmark is enabled
+   */
+  public ApplicationSpec(
+      String name,
+      String group,
+      String icon,
+      String iconColor,
+      String url,
+      String info,
+      Boolean targetBlank,
+      int location,
+      Boolean enabled) {
+    this.name = name;
+    this.group = group;
+    this.icon = icon;
+    this.iconColor = iconColor;
+    this.url = url;
+    this.info = info;
+    this.targetBlank = targetBlank;
+    this.location = location;
+    this.enabled = enabled;
+    this.rootPath = null;
+    this.tags = null;
+  }
+
+  /**
+   * Parameterized constructor to initialize all fields.
+   *
+   * @param name the application name (required)
+   * @param group the group the bookmark belongs to
+   * @param icon the application icon
+   * @param iconColor the icon color
+   * @param url the application URL (required)
+   * @param info description of the bookmark
+   * @param targetBlank whether to open the URL in a new tab
+   * @param location sorting order of the bookmark
+   * @param enabled whether the bookmark is enabled
+   * @param rootPath root path to append to the URL
+   */
+  public ApplicationSpec(
+      String name,
+      String group,
+      String icon,
+      String iconColor,
+      String url,
+      String info,
+      Boolean targetBlank,
+      int location,
+      Boolean enabled,
+      String rootPath) {
+    this.name = name;
+    this.group = group;
+    this.icon = icon;
+    this.iconColor = iconColor;
+    this.url = url;
+    this.info = info;
+    this.targetBlank = targetBlank;
+    this.location = location;
+    this.enabled = enabled;
+    this.rootPath = rootPath;
+    this.tags = null;
+  }
+
+  /**
+   * Parameterized constructor to initialize all fields including tags.
+   *
+   * @param name the application name (required)
+   * @param group the group the bookmark belongs to
+   * @param icon the application icon
+   * @param iconColor the icon color
+   * @param url the application URL (required)
+   * @param info description of the bookmark
+   * @param targetBlank whether to open the URL in a new tab
+   * @param location sorting order of the bookmark
+   * @param enabled whether the bookmark is enabled
+   * @param rootPath root path to append to the URL
+   * @param tags comma-separated tags for filtering
+   */
+  public ApplicationSpec(
+      String name,
+      String group,
+      String icon,
+      String iconColor,
+      String url,
+      String info,
+      Boolean targetBlank,
+      int location,
+      Boolean enabled,
+      String rootPath,
+      String tags) {
+    this.name = name;
+    this.group = group;
+    this.icon = icon;
+    this.iconColor = iconColor;
+    this.url = url;
+    this.info = info;
+    this.targetBlank = targetBlank;
+    this.location = location;
+    this.enabled = enabled;
+    this.rootPath = rootPath;
+    this.tags = tags;
+  }
+
+  /**
+   * Gets the name of the application bookmark.
+   *
+   * @return application name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Sets the name of the application bookmark.
+   *
+   * @param name application name
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Gets the group this bookmark belongs to.
+   *
+   * @return group the bookmark belongs to
+   */
+  public String getGroup() {
+    return group;
+  }
+
+  /**
+   * Sets the group this bookmark belongs to.
+   *
+   * @param group the group name
+   */
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  /**
+   * Gets the icon for this bookmark.
+   *
+   * @return application icon
+   */
+  public String getIcon() {
+    return icon;
+  }
+
+  /**
+   * Sets the icon for this bookmark.
+   *
+   * @param icon icon name or URL
+   */
+  public void setIcon(String icon) {
+    this.icon = icon;
+  }
+
+  /**
+   * Gets the color of the bookmark icon.
+   *
+   * @return icon color
+   */
+  public String getIconColor() {
+    return iconColor;
+  }
+
+  /**
+   * Sets the color of the bookmark icon.
+   *
+   * @param iconColor icon color name
+   */
+  public void setIconColor(String iconColor) {
+    this.iconColor = iconColor;
+  }
+
+  /**
+   * Gets the URL the bookmark points to.
+   *
+   * @return application URL
+   */
+  public String getUrl() {
+    return url;
+  }
+
+  /**
+   * Sets the URL the bookmark points to.
+   *
+   * @param url application URL
+   */
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  /**
+   * Gets the optional info or description of the bookmark.
+   *
+   * @return additional info or description
+   */
+  public String getInfo() {
+    return info;
+  }
+
+  /**
+   * Sets the optional info or description of the bookmark.
+   *
+   * @param info additional bookmark info
+   */
+  public void setInfo(String info) {
+    this.info = info;
+  }
+
+  /**
+   * Gets whether the URL should open in a new browser tab.
+   *
+   * @return true if the link should open in a new tab
+   */
+  public Boolean getTargetBlank() {
+    return targetBlank;
+  }
+
+  /**
+   * Sets whether the URL should open in a new browser tab.
+   *
+   * @param targetBlank whether to open the URL in a new tab
+   */
+  public void setTargetBlank(Boolean targetBlank) {
+    this.targetBlank = targetBlank;
+  }
+
+  /**
+   * Gets the sorting order of the bookmark.
+   *
+   * @return sorting order
+   */
+  public int getLocation() {
+    return location;
+  }
+
+  /**
+   * Sets the sorting order of the bookmark.
+   *
+   * @param location sorting order
+   */
+  public void setLocation(int location) {
+    this.location = location;
+  }
+
+  /**
+   * Gets whether the bookmark is enabled.
+   *
+   * @return true if the bookmark is enabled
+   */
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Sets whether the bookmark is enabled.
+   *
+   * @param enabled whether the bookmark is enabled
+   */
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  /**
+   * Gets the root path to append to the URL.
+   *
+   * @return root path string
+   */
+  public String getRootPath() {
+    return rootPath;
+  }
+
+  /**
+   * Sets the root path to append to the URL.
+   *
+   * @param rootPath root path string
+   */
+  public void setRootPath(String rootPath) {
+    this.rootPath = rootPath;
+  }
+
+  /**
+   * Gets the comma-separated tags for filtering applications.
+   *
+   * @return tags string
+   */
+  public String getTags() {
+    return tags;
+  }
+
+  /**
+   * Sets the comma-separated tags for filtering applications.
+   *
+   * @param tags comma-separated tags string
+   */
+  public void setTags(String tags) {
+    this.tags = tags;
+  }
+
+  /**
+   * Compares this ApplicationSpec with another for sorting by group, location, and name.
+   *
+   * @param other the other ApplicationSpec
+   * @return negative, zero, or positive integer
+   */
+  @Override
+  public int compareTo(ApplicationSpec other) {
+    int groupCompare = this.getGroup().compareTo(other.getGroup());
+    if (groupCompare != 0) {
+      return groupCompare;
+    }
+
+    int locationCompare = Integer.compare(this.getLocation(), other.getLocation());
+    if (locationCompare != 0) {
+      return locationCompare;
+    }
+
+    return this.getName().compareTo(other.getName());
+  }
+
+  /**
+   * Checks if this ApplicationSpec is equal to another object.
+   *
+   * @param o other object
+   * @return true if equal
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ApplicationSpec that = (ApplicationSpec) o;
+
+    if (location != that.location) {
+      return false;
+    }
+    if (name != null ? !name.equals(that.name) : that.name != null) {
+      return false;
+    }
+    if (group != null ? !group.equals(that.group) : that.group != null) {
+      return false;
+    }
+    if (icon != null ? !icon.equals(that.icon) : that.icon != null) {
+      return false;
+    }
+    if (iconColor != null ? !iconColor.equals(that.iconColor) : that.iconColor != null) {
+      return false;
+    }
+    if (url != null ? !url.equals(that.url) : that.url != null) {
+      return false;
+    }
+    if (info != null ? !info.equals(that.info) : that.info != null) {
+      return false;
+    }
+    if (targetBlank != null ? !targetBlank.equals(that.targetBlank) : that.targetBlank != null) {
+      return false;
+    }
+    if (enabled != null ? !enabled.equals(that.enabled) : that.enabled != null) {
+      return false;
+    }
+    if (rootPath != null ? !rootPath.equals(that.rootPath) : that.rootPath != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Computes a hash code for this ApplicationSpec.
+   *
+   * @return hash code
+   */
+  @Override
+  public int hashCode() {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (group != null ? group.hashCode() : 0);
+    result = 31 * result + (icon != null ? icon.hashCode() : 0);
+    result = 31 * result + (iconColor != null ? iconColor.hashCode() : 0);
+    result = 31 * result + (url != null ? url.hashCode() : 0);
+    result = 31 * result + (info != null ? info.hashCode() : 0);
+    result = 31 * result + (targetBlank != null ? targetBlank.hashCode() : 0);
+    result = 31 * result + location;
+    result = 31 * result + (enabled != null ? enabled.hashCode() : 0);
+    result = 31 * result + (rootPath != null ? rootPath.hashCode() : 0);
+    return result;
+  }
+
+  /**
+   * Returns a string representation of this ApplicationSpec.
+   *
+   * @return string with field values
+   */
+  @Override
+  public String toString() {
+    return "ApplicationSpec{"
+        + "name='"
+        + name
+        + '\''
+        + ", group='"
+        + group
+        + '\''
+        + ", icon='"
+        + icon
+        + '\''
+        + ", iconColor='"
+        + iconColor
+        + '\''
+        + ", url='"
+        + url
+        + '\''
+        + ", info='"
+        + info
+        + '\''
+        + ", targetBlank="
+        + targetBlank
+        + ", location="
+        + location
+        + ", enabled="
+        + enabled
+        + ", rootPath='"
+        + rootPath
+        + '\''
+        + ", tags='"
+        + tags
+        + '\''
+        + '}';
+  }
+}

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/ApplicationStatus.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/ApplicationStatus.java
@@ -1,0 +1,22 @@
+package us.ullberg.startpunkt.crd.v1alpha3;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Represents the status of an {@link Application} custom resource. This class can be extended to
+ * include status-related fields.
+ *
+ * <p>Non-empty JSON properties are included in serialization.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class ApplicationStatus {
+  /**
+   * Creates an empty ApplicationStatus. Explicit constructor provided for clarity and documentation
+   * compliance.
+   */
+  public ApplicationStatus() {
+    super();
+  }
+
+  // This class is currently empty, but it can be extended to include status fields
+}

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/Bookmark.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/Bookmark.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -13,7 +13,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * Represents a Kubernetes custom resource for a Bookmark. This resource is namespaced and includes
  * specifications and status.
  */
-@Version(value = "v1alpha2", storage = false, served = true, deprecated = true)
+@Version(value = "v1alpha3", storage = true, served = true, deprecated = false)
 @Group("startpunkt.ullberg.us")
 @Plural("bookmarks")
 public class Bookmark extends CustomResource<BookmarkSpec, BookmarkStatus> implements Namespaced {

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/BookmarkList.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/BookmarkList.java
@@ -1,0 +1,20 @@
+package us.ullberg.startpunkt.crd.v1alpha3;
+
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
+
+/**
+ * Represents a list of {@link Bookmark} custom resources. Extends {@link
+ * DefaultKubernetesResourceList} to provide standard list behavior.
+ */
+public class BookmarkList extends DefaultKubernetesResourceList<Bookmark> {
+
+  /**
+   * Creates an empty BookmarkList. Required to satisfy tools that enforce explicit constructor
+   * documentation.
+   */
+  public BookmarkList() {
+    super();
+  }
+
+  // No additional implementation needed; inherits list behavior.
+}

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/BookmarkSpec.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/BookmarkSpec.java
@@ -1,0 +1,302 @@
+package us.ullberg.startpunkt.crd.v1alpha3;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.fabric8.generator.annotation.Required;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Represents the specification of a Bookmark custom resource. Includes properties such as name,
+ * group, icon, URL, info, target behavior, and sorting location.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@RegisterForReflection(registerFullHierarchy = true)
+public class BookmarkSpec implements Comparable<BookmarkSpec> {
+
+  /** Bookmark name (required). */
+  @JsonProperty("name")
+  @JsonPropertyDescription("Bookmark name")
+  @Required
+  public String name;
+
+  /** Group the bookmark belongs to (required). */
+  @JsonProperty("group")
+  @JsonPropertyDescription("Group the bookmark belongs to")
+  @Required
+  private String group;
+
+  /** Bookmark icon (optional), e.g. icon name or URL. */
+  @JsonProperty("icon")
+  @JsonPropertyDescription("Bookmark icon, e.g. 'mdi:home', 'https://example.com/icon.png'")
+  private String icon;
+
+  /** Bookmark URL (required). */
+  @JsonProperty("url")
+  @JsonPropertyDescription("Bookmark URL")
+  @Required
+  private String url;
+
+  /** Description or additional info about the bookmark (optional). */
+  @JsonProperty("info")
+  @JsonPropertyDescription("Description of the bookmark")
+  private String info;
+
+  /** Whether the URL should open in a new tab (optional). */
+  @JsonProperty("targetBlank")
+  @JsonPropertyDescription("Open the URL in a new tab")
+  private Boolean targetBlank;
+
+  /** Sorting order for bookmarks (optional). Lower numbers sort first. */
+  @JsonProperty("location")
+  @JsonPropertyDescription("Sorting order of the bookmark")
+  private int location;
+
+  /** Default no-argument constructor. */
+  public BookmarkSpec() {}
+
+  /**
+   * Constructs a BookmarkSpec with all properties.
+   *
+   * @param name bookmark name
+   * @param group bookmark group
+   * @param icon bookmark icon (optional)
+   * @param url bookmark URL
+   * @param info description or info (optional)
+   * @param targetBlank whether to open in new tab (optional)
+   * @param location sorting order
+   */
+  public BookmarkSpec(
+      String name,
+      String group,
+      String icon,
+      String url,
+      String info,
+      Boolean targetBlank,
+      int location) {
+    this.name = name;
+    this.group = group;
+    this.icon = icon;
+    this.url = url;
+    this.info = info;
+    this.targetBlank = targetBlank;
+    this.location = location;
+  }
+
+  /**
+   * Get the bookmark name.
+   *
+   * @return the bookmark name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Set the bookmark name.
+   *
+   * @param name the bookmark name to set
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Get the bookmark group.
+   *
+   * @return the bookmark group
+   */
+  public String getGroup() {
+    return group;
+  }
+
+  /**
+   * Set the bookmark group.
+   *
+   * @param group the bookmark group to set
+   */
+  public void setGroup(String group) {
+    this.group = group;
+  }
+
+  /**
+   * Get the bookmark icon.
+   *
+   * @return the bookmark icon
+   */
+  public String getIcon() {
+    return icon;
+  }
+
+  /**
+   * Set the bookmark icon.
+   *
+   * @param icon the bookmark icon to set
+   */
+  public void setIcon(String icon) {
+    this.icon = icon;
+  }
+
+  /**
+   * Get the bookmark url.
+   *
+   * @return the bookmark URL
+   */
+  public String getUrl() {
+    return url;
+  }
+
+  /**
+   * Set the bookmark url.
+   *
+   * @param url the bookmark URL to set
+   */
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  /**
+   * Get the bookmark info.
+   *
+   * @return the bookmark info/description
+   */
+  public String getInfo() {
+    return info;
+  }
+
+  /**
+   * Set the bookmark info.
+   *
+   * @param info the bookmark info to set
+   */
+  public void setInfo(String info) {
+    this.info = info;
+  }
+
+  /**
+   * Get whether the url should open in a new tab.
+   *
+   * @return whether the URL should open in a new tab
+   */
+  public Boolean getTargetBlank() {
+    return targetBlank;
+  }
+
+  /**
+   * Set whether the url should open in a new tab.
+   *
+   * @param targetBlank the targetBlank flag to set
+   */
+  public void setTargetBlank(Boolean targetBlank) {
+    this.targetBlank = targetBlank;
+  }
+
+  /**
+   * Get the sorting location.
+   *
+   * @return the sorting location of the bookmark
+   */
+  public int getLocation() {
+    return location;
+  }
+
+  /**
+   * Set the sorting location.
+   *
+   * @param location the sorting location to set
+   */
+  public void setLocation(int location) {
+    this.location = location;
+  }
+
+  /**
+   * Compares two BookmarkSpec objects for sorting order. Sorting priority: group, then location,
+   * then name.
+   *
+   * @param other another BookmarkSpec to compare against
+   * @return negative if this precedes other, positive if after, zero if equal
+   */
+  @Override
+  public int compareTo(BookmarkSpec other) {
+    int groupCompare = this.getGroup().compareTo(other.getGroup());
+    if (groupCompare != 0) {
+      return groupCompare;
+    }
+
+    int locationCompare = Integer.compare(this.getLocation(), other.getLocation());
+    if (locationCompare != 0) {
+      return locationCompare;
+    }
+
+    return this.getName().compareTo(other.getName());
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    BookmarkSpec otherSpec = (BookmarkSpec) other;
+    if (location != otherSpec.location) {
+      return false;
+    }
+    if (name != null ? !name.equals(otherSpec.name) : otherSpec.name != null) {
+      return false;
+    }
+    if (group != null ? !group.equals(otherSpec.group) : otherSpec.group != null) {
+      return false;
+    }
+    if (icon != null ? !icon.equals(otherSpec.icon) : otherSpec.icon != null) {
+      return false;
+    }
+    if (url != null ? !url.equals(otherSpec.url) : otherSpec.url != null) {
+      return false;
+    }
+    if (info != null ? !info.equals(otherSpec.info) : otherSpec.info != null) {
+      return false;
+    }
+    return targetBlank != null
+        ? targetBlank.equals(otherSpec.targetBlank)
+        : otherSpec.targetBlank == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name != null ? name.hashCode() : 0;
+    result = 31 * result + (group != null ? group.hashCode() : 0);
+    result = 31 * result + (icon != null ? icon.hashCode() : 0);
+    result = 31 * result + (url != null ? url.hashCode() : 0);
+    result = 31 * result + (info != null ? info.hashCode() : 0);
+    result = 31 * result + (targetBlank != null ? targetBlank.hashCode() : 0);
+    result = 31 * result + location;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "BookmarkSpec{"
+        + "name='"
+        + name
+        + '\''
+        + ", group='"
+        + group
+        + '\''
+        + ", icon='"
+        + icon
+        + '\''
+        + ", url='"
+        + url
+        + '\''
+        + ", info='"
+        + info
+        + '\''
+        + ", targetBlank="
+        + targetBlank
+        + ", location="
+        + location
+        + '}';
+  }
+}

--- a/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/BookmarkStatus.java
+++ b/src/main/java/us/ullberg/startpunkt/crd/v1alpha3/BookmarkStatus.java
@@ -1,0 +1,20 @@
+package us.ullberg.startpunkt.crd.v1alpha3;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Represents the status subresource of a Bookmark custom resource.
+ *
+ * <p>This class is currently empty but can be extended to include status-related fields such as
+ * status messages, timestamps, or other runtime information about the Bookmark resource.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class BookmarkStatus {
+  /** Default constructor. */
+  public BookmarkStatus() {
+    // No special initialization needed
+  }
+
+  // Intentionally left empty for future status fields
+
+}

--- a/src/main/java/us/ullberg/startpunkt/objects/ApplicationGroup.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/ApplicationGroup.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.LinkedList;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /**
  * Represents a group of applications, each group identified by a name and containing a list of

--- a/src/main/java/us/ullberg/startpunkt/objects/BookmarkGroup.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/BookmarkGroup.java
@@ -5,7 +5,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.BookmarkSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.BookmarkSpec;
 
 /**
  * Represents a group of bookmarks with a name and a list of {@link BookmarkSpec}. Implements

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/AnnotatedKubernetesObject.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/AnnotatedKubernetesObject.java
@@ -2,7 +2,7 @@ package us.ullberg.startpunkt.objects.kubernetes;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /**
  * Abstract base class for Kubernetes objects that extract application properties from annotations.
@@ -227,6 +227,21 @@ public abstract class AnnotatedKubernetesObject extends BaseKubernetesObject {
       }
     }
     return super.getAppProtocol(item);
+  }
+
+  /**
+   * Retrieves the application tags from resource annotations.
+   *
+   * @param item Kubernetes resource
+   * @return comma-separated tags string or null if not set
+   */
+  protected String getAppTags(GenericKubernetesResource item) {
+    var annotations = getAnnotations(item);
+
+    if (annotations != null && annotations.containsKey("startpunkt.ullberg.us/tags")) {
+      return annotations.get("startpunkt.ullberg.us/tags");
+    }
+    return null;
   }
 
   /**

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/BaseKubernetesObject.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/BaseKubernetesObject.java
@@ -7,7 +7,7 @@ import io.fabric8.kubernetes.client.dsl.base.ResourceDefinitionContext;
 import jakarta.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /**
  * Abstract base class representing a Kubernetes custom resource wrapper. Provides common
@@ -139,7 +139,9 @@ public abstract class BaseKubernetesObject implements KubernetesObject {
         getAppInfo(item),
         getAppTargetBlank(item),
         getAppLocation(item),
-        getAppEnabled(item));
+        getAppEnabled(item),
+        getAppRootPath(item),
+        getAppTags(item));
   }
 
   /**
@@ -149,6 +151,9 @@ public abstract class BaseKubernetesObject implements KubernetesObject {
    * @return map of annotations or null if none present
    */
   protected Map<String, String> getAnnotations(GenericKubernetesResource item) {
+    if (item.getMetadata() == null) {
+      return null;
+    }
     return item.getMetadata().getAnnotations();
   }
 
@@ -276,6 +281,21 @@ public abstract class BaseKubernetesObject implements KubernetesObject {
    * @return protocol string or null if not specified
    */
   protected String getAppProtocol(GenericKubernetesResource item) {
+    return null;
+  }
+
+  /**
+   * Returns the tags of the application. By default, reads from the
+   * "startpunkt.ullberg.us/tags" annotation.
+   *
+   * @param item the Kubernetes generic resource
+   * @return comma-separated tags string or null if not set
+   */
+  protected String getAppTags(GenericKubernetesResource item) {
+    var annotations = getAnnotations(item);
+    if (annotations != null && annotations.containsKey("startpunkt.ullberg.us/tags")) {
+      return annotations.get("startpunkt.ullberg.us/tags");
+    }
     return null;
   }
 

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/GatewayApiHttpRouteWrapper.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/GatewayApiHttpRouteWrapper.java
@@ -4,7 +4,7 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.ArrayList;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /**
  * Wrapper class for Kubernetes Gateway API HTTPRoute resources. Provides methods to extract

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/IngressApplicationWrapper.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/IngressApplicationWrapper.java
@@ -2,7 +2,7 @@ package us.ullberg.startpunkt.objects.kubernetes;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /**
  * Wrapper class for Kubernetes Ingress resources. Allows retrieval of application specifications

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/IstioVirtualServiceApplicationWrapper.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/IstioVirtualServiceApplicationWrapper.java
@@ -4,7 +4,7 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.ArrayList;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /**
  * Wrapper for Istio VirtualService custom resources to extract application info. Supports filtering

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/KubernetesObject.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/KubernetesObject.java
@@ -2,7 +2,7 @@ package us.ullberg.startpunkt.objects.kubernetes;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /** Defines methods for Kubernetes resource wrappers that retrieve application specifications. */
 public interface KubernetesObject {

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/RouteApplicationWrapper.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/RouteApplicationWrapper.java
@@ -3,7 +3,7 @@ package us.ullberg.startpunkt.objects.kubernetes;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import java.util.List;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 /**
  * Wrapper for OpenShift Route custom resources to extract application information. Supports

--- a/src/main/java/us/ullberg/startpunkt/objects/kubernetes/StartpunktApplicationWrapper.java
+++ b/src/main/java/us/ullberg/startpunkt/objects/kubernetes/StartpunktApplicationWrapper.java
@@ -11,10 +11,10 @@ public class StartpunktApplicationWrapper extends BaseKubernetesObject {
 
   /**
    * Constructs a StartpunktApplicationWrapper with group "startpunkt.ullberg.us", version
-   * "v1alpha2", and plural "applications".
+   * "v1alpha3", and plural "applications".
    */
   public StartpunktApplicationWrapper() {
-    super("startpunkt.ullberg.us", "v1alpha2", "applications");
+    super("startpunkt.ullberg.us", "v1alpha3", "applications");
   }
 
   /**
@@ -136,5 +136,16 @@ public class StartpunktApplicationWrapper extends BaseKubernetesObject {
   @Override
   protected Boolean getAppEnabled(GenericKubernetesResource item) {
     return getOptionalSpecBoolean(item, "enabled", super.getAppEnabled(item));
+  }
+
+  /**
+   * Retrieves the tags from the resource spec. Returns base class tags if not present.
+   *
+   * @param item Kubernetes resource
+   * @return comma-separated tags string
+   */
+  @Override
+  protected String getAppTags(GenericKubernetesResource item) {
+    return getOptionalSpecString(item, "tags", super.getAppTags(item));
   }
 }

--- a/src/main/java/us/ullberg/startpunkt/rest/BookmarkResource.java
+++ b/src/main/java/us/ullberg/startpunkt/rest/BookmarkResource.java
@@ -19,7 +19,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import us.ullberg.startpunkt.crd.v1alpha2.BookmarkSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.BookmarkSpec;
 import us.ullberg.startpunkt.objects.BookmarkGroup;
 import us.ullberg.startpunkt.objects.BookmarkGroupList;
 import us.ullberg.startpunkt.service.BookmarkService;

--- a/src/main/java/us/ullberg/startpunkt/service/BookmarkService.java
+++ b/src/main/java/us/ullberg/startpunkt/service/BookmarkService.java
@@ -13,7 +13,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import us.ullberg.startpunkt.crd.v1alpha2.BookmarkSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.BookmarkSpec;
 import us.ullberg.startpunkt.objects.BookmarkGroup;
 
 /**
@@ -46,7 +46,7 @@ public class BookmarkService {
       ResourceDefinitionContext ctx =
           new ResourceDefinitionContext.Builder()
               .withGroup("startpunkt.ullberg.us")
-              .withVersion("v1alpha2")
+              .withVersion("v1alpha3")
               .withPlural("bookmarks")
               .withNamespaced(true)
               .build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.quinoa.package-manager-install.node-version=20.11.1
 quarkus.quinoa.package-manager-install.npm-version=10.8.1
 quarkus.quinoa.package-manager-install.pnpm-version=8.15.3
 quarkus.quinoa.package-manager=npm
+quarkus.quinoa.enable-spa-routing=true
 
 quarkus.helm.name=startpunkt
 quarkus.helm.description=Deploy the Startpunkt application

--- a/src/main/webui/src/app.jsx
+++ b/src/main/webui/src/app.jsx
@@ -183,8 +183,19 @@ export function App() {
   const [applicationGroups, setApplicationGroups] = useState(null);
   const [bookmarkGroups, setBookmarkGroups] = useState(null);
 
+  // Extract tags from URL path for filtering
+  const getTagsFromUrl = () => {
+    const pathname = window.location.pathname;
+    // Remove leading slash and return tags if present
+    const path = pathname.replace(/^\//, '');
+    return path && path !== '' ? path : null;
+  };
+
   useEffect(() => {
-    fetch('/api/apps')
+    const tags = getTagsFromUrl();
+    const appsEndpoint = tags ? `/api/apps/${encodeURIComponent(tags)}` : '/api/apps';
+    
+    fetch(appsEndpoint)
       .then(res => res.json())
       .then(res => {
         setApplicationGroups(res.groups || []);

--- a/src/main/webui/src/app.test.jsx
+++ b/src/main/webui/src/app.test.jsx
@@ -336,4 +336,6 @@ describe('App', () => {
       expect(screen.getByRole('navigation')).toBeEmptyDOMElement();
     });
   });
+
+
 });

--- a/src/main/webui/src/tagParsing.test.jsx
+++ b/src/main/webui/src/tagParsing.test.jsx
@@ -1,0 +1,80 @@
+// Test the tag parsing logic directly without importing from app.jsx
+function testGetTagsFromUrl(pathname) {
+  if (!pathname || pathname === '/') {
+    return null;
+  }
+  
+  // Remove leading slash and trailing slash if present
+  const path = pathname.startsWith('/') ? pathname.slice(1) : pathname;
+  const cleanPath = path.endsWith('/') ? path.slice(0, -1) : path;
+  
+  return cleanPath || null;
+}
+
+describe('URL Tag Parsing', () => {
+  it('returns null for root path', () => {
+    expect(testGetTagsFromUrl('/')).toBe(null);
+  });
+
+  it('returns null for empty string', () => {
+    expect(testGetTagsFromUrl('')).toBe(null);
+  });
+
+  it('returns null for undefined', () => {
+    expect(testGetTagsFromUrl()).toBe(null);
+  });
+
+  it('extracts single tag from URL', () => {
+    expect(testGetTagsFromUrl('/admin')).toBe('admin');
+  });
+
+  it('extracts multiple tags from URL', () => {
+    expect(testGetTagsFromUrl('/admin,dev,prod')).toBe('admin,dev,prod');
+  });
+
+  it('handles trailing slash', () => {
+    expect(testGetTagsFromUrl('/admin,dev/')).toBe('admin,dev');
+  });
+
+  it('handles complex tag combinations', () => {
+    expect(testGetTagsFromUrl('/production,monitoring,alerts')).toBe('production,monitoring,alerts');
+  });
+
+  it('handles single character tags', () => {
+    expect(testGetTagsFromUrl('/a,b,c')).toBe('a,b,c');
+  });
+
+  it('handles tags with numbers', () => {
+    expect(testGetTagsFromUrl('/v1,v2,beta')).toBe('v1,v2,beta');
+  });
+
+  it('returns just the tag without slash prefix', () => {
+    expect(testGetTagsFromUrl('/test-tag')).toBe('test-tag');
+  });
+});
+
+describe('API Endpoint Construction', () => {
+  it('constructs filtered endpoint for single tag', () => {
+    const tags = 'admin';
+    const endpoint = `/api/apps/${tags}`;
+    expect(endpoint).toBe('/api/apps/admin');
+  });
+
+  it('constructs filtered endpoint for multiple tags', () => {
+    const tags = 'admin,dev,prod';
+    const endpoint = `/api/apps/${tags}`;
+    expect(endpoint).toBe('/api/apps/admin,dev,prod');
+  });
+
+  it('constructs default endpoint when tags is null', () => {
+    const tags = null;
+    const endpoint = tags ? `/api/apps/${tags}` : '/api/apps';
+    expect(endpoint).toBe('/api/apps');
+  });
+
+  it('constructs default endpoint when tags is empty', () => {
+    const tags = '';
+    const endpoint = tags ? `/api/apps/${tags}` : '/api/apps';
+    expect(endpoint).toBe('/api/apps');
+  });
+});

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationListIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationListIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationListTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationListTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationSpecIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationSpecIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationSpecTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationSpecTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationStatusIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationStatusIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationStatusTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationStatusTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/ApplicationTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/ApplicationTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkListIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkListIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkListTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkListTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkSpecIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkSpecIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkSpecTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkSpecTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkStatusIT.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkStatusIT.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkStatusTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkStatusTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/crd/BookmarkTest.java
+++ b/src/test/java/us/ullberg/startpunkt/crd/BookmarkTest.java
@@ -1,4 +1,4 @@
-package us.ullberg.startpunkt.crd.v1alpha2;
+package us.ullberg.startpunkt.crd.v1alpha3;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/us/ullberg/startpunkt/objects/ApplicationGroupTest.java
+++ b/src/test/java/us/ullberg/startpunkt/objects/ApplicationGroupTest.java
@@ -14,7 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import us.ullberg.startpunkt.crd.v1alpha2.ApplicationSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.ApplicationSpec;
 
 class ApplicationGroupTest {
 

--- a/src/test/java/us/ullberg/startpunkt/objects/BookmarkGroupTest.java
+++ b/src/test/java/us/ullberg/startpunkt/objects/BookmarkGroupTest.java
@@ -10,7 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import us.ullberg.startpunkt.crd.v1alpha2.BookmarkSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.BookmarkSpec;
 
 class BookmarkGroupTest {
 

--- a/src/test/java/us/ullberg/startpunkt/objects/kubernetes/AnnotatedKubernetesObjectTest.java
+++ b/src/test/java/us/ullberg/startpunkt/objects/kubernetes/AnnotatedKubernetesObjectTest.java
@@ -168,4 +168,97 @@ class AnnotatedKubernetesObjectTest {
 
     assertEquals("https://custom.example.com/web/index.html", result);
   }
+
+  // ---- Tag Tests ----
+
+  @Test
+  void testGetAppTagsWithValidTags() {
+    // Create a mock resource with tags annotation
+    GenericKubernetesResource resource = new GenericKubernetesResource();
+    ObjectMeta metadata = new ObjectMeta();
+    Map<String, String> annotations = new HashMap<>();
+    annotations.put("startpunkt.ullberg.us/tags", "admin,dev,test");
+    metadata.setAnnotations(annotations);
+    resource.setMetadata(metadata);
+
+    TestAnnotatedKubernetesObject testObj = new TestAnnotatedKubernetesObject();
+    String result = testObj.getAppTags(resource);
+
+    assertEquals("admin,dev,test", result);
+  }
+
+  @Test
+  void testGetAppTagsWithSingleTag() {
+    // Create a mock resource with single tag annotation
+    GenericKubernetesResource resource = new GenericKubernetesResource();
+    ObjectMeta metadata = new ObjectMeta();
+    Map<String, String> annotations = new HashMap<>();
+    annotations.put("startpunkt.ullberg.us/tags", "production");
+    metadata.setAnnotations(annotations);
+    resource.setMetadata(metadata);
+
+    TestAnnotatedKubernetesObject testObj = new TestAnnotatedKubernetesObject();
+    String result = testObj.getAppTags(resource);
+
+    assertEquals("production", result);
+  }
+
+  @Test
+  void testGetAppTagsWithNoAnnotation() {
+    // Create a mock resource without tags annotation
+    GenericKubernetesResource resource = new GenericKubernetesResource();
+    ObjectMeta metadata = new ObjectMeta();
+    Map<String, String> annotations = new HashMap<>();
+    metadata.setAnnotations(annotations);
+    resource.setMetadata(metadata);
+
+    TestAnnotatedKubernetesObject testObj = new TestAnnotatedKubernetesObject();
+    String result = testObj.getAppTags(resource);
+
+    assertNull(result);
+  }
+
+  @Test
+  void testGetAppTagsWithEmptyTags() {
+    // Create a mock resource with empty tags annotation
+    GenericKubernetesResource resource = new GenericKubernetesResource();
+    ObjectMeta metadata = new ObjectMeta();
+    Map<String, String> annotations = new HashMap<>();
+    annotations.put("startpunkt.ullberg.us/tags", "");
+    metadata.setAnnotations(annotations);
+    resource.setMetadata(metadata);
+
+    TestAnnotatedKubernetesObject testObj = new TestAnnotatedKubernetesObject();
+    String result = testObj.getAppTags(resource);
+
+    assertEquals("", result);
+  }
+
+  @Test
+  void testGetAppTagsWithWhitespaceInTags() {
+    // Create a mock resource with tags containing whitespace
+    GenericKubernetesResource resource = new GenericKubernetesResource();
+    ObjectMeta metadata = new ObjectMeta();
+    Map<String, String> annotations = new HashMap<>();
+    annotations.put("startpunkt.ullberg.us/tags", " admin , dev , test ");
+    metadata.setAnnotations(annotations);
+    resource.setMetadata(metadata);
+
+    TestAnnotatedKubernetesObject testObj = new TestAnnotatedKubernetesObject();
+    String result = testObj.getAppTags(resource);
+
+    assertEquals(" admin , dev , test ", result);
+  }
+
+  @Test
+  void testGetAppTagsWithNoMetadata() {
+    // Create a mock resource without metadata
+    GenericKubernetesResource resource = new GenericKubernetesResource();
+    resource.setMetadata(null);
+
+    TestAnnotatedKubernetesObject testObj = new TestAnnotatedKubernetesObject();
+    String result = testObj.getAppTags(resource);
+
+    assertNull(result);
+  }
 }

--- a/src/test/java/us/ullberg/startpunkt/rest/BookmarkResourceTest.java
+++ b/src/test/java/us/ullberg/startpunkt/rest/BookmarkResourceTest.java
@@ -15,8 +15,8 @@ import io.quarkus.test.kubernetes.client.WithKubernetesTestServer;
 import java.net.HttpURLConnection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import us.ullberg.startpunkt.crd.v1alpha2.Bookmark;
-import us.ullberg.startpunkt.crd.v1alpha2.BookmarkSpec;
+import us.ullberg.startpunkt.crd.v1alpha3.Bookmark;
+import us.ullberg.startpunkt.crd.v1alpha3.BookmarkSpec;
 import us.ullberg.startpunkt.service.BookmarkService;
 
 // Mark this class as a Quarkus test


### PR DESCRIPTION
This feature allows filtering applications based on tags. You can filter applications by passing tags as URL parameters, showing only applications that match the specified tags or applications with no tags.

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changed Bookmark and Application CRDs to version v1alpha3, including updates to their specifications and status classes.
- Added support for tags in Application and Bookmark specifications for enhanced filtering capabilities.
- Implemented tag filtering logic in the application resource, allowing users to filter applications based on tags via URL parameters.
- Introduced comprehensive documentation for object tag filtering, detailing usage and examples.
- Added unit tests for tag parsing and API endpoint construction to ensure correct functionality.

## Does this introduce a breaking change?

- [x] Yes (if you dont update the CRDs)
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
