### PR TITLE
chore(renovate): hold @babel/preset-env and preset-react on 7.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,6 +70,17 @@
          "commitMessagePrefix": "feat(js)!: "
       },
       {
+         "description": "Hold the Babel presets on 7.x. Babel 8 requires @babel/core ^8, but @preact/preset-vite (through 2.10.6) declares a hard \"@babel/core\": \"7.x\" peer, so Babel 8 cannot be installed here at all - npm install fails with ERESOLVE. Drop this rule once @preact/preset-vite supports Babel 8.",
+         "matchDatasources": [
+            "npm"
+         ],
+         "matchPackageNames": [
+            "@babel/preset-env",
+            "@babel/preset-react"
+         ],
+         "allowedVersions": "<8"
+      },
+      {
          "matchDatasources": [
             "npm"
          ],


### PR DESCRIPTION
Follow-up to #828.

## Why

Babel 8 requires `@babel/core@^8`, but `@preact/preset-vite` — including its latest `2.10.6` — declares a hard `"@babel/core": "7.x"` peer. Babel 8 therefore cannot be installed in this project at all: `npm install` fails with `ERESOLVE` before the build or tests run.

That is exactly what broke #758. Nothing currently tells Renovate the bump is impossible, so it will keep pulling `@babel/preset-env@^8` and `@babel/preset-react@^8` back into the `all-npm-major` group every cycle and re-breaking that PR.

## Change

Adds one `packageRules` entry constraining both presets to `allowedVersions: "<8"`, with a `description` recording the reason and the condition for removal.

Drop the rule once `@preact/preset-vite` supports Babel 8.

## Verification

`renovate-config-validator` passes against both the pinned and the latest Renovate schema:

```
INFO: Validating renovate.json
INFO: Config validated successfully
```